### PR TITLE
swapped the default i3 exit menu with the rofi shutdown menu

### DIFF
--- a/.config/i3/config
+++ b/.config/i3/config
@@ -202,7 +202,7 @@ bindsym $mod+Shift+c reload
 bindsym $mod+Shift+r restart
 
 # exit i3 (logs you out of your X session)
-bindsym $mod+Shift+q exec "i3-nagbar -t warning -m 'You pressed the exit shortcut. Do you really want to exit i3? This will end your X session.' -b 'Yes, exit i3' 'i3-msg exit'"
+bindsym $mod+Shift+q exec --no-startup-id ~/.config/i3/scripts/shutdown_menu -p rofi -c
 
 
 # resize window (you can also use the mouse for that)


### PR DESCRIPTION
I swapped out the default i3 exit menu bound to `$mod+Shift+q` with the rofi shutdown menu included to give more options